### PR TITLE
DIADO-3138 modify or remove some checks to bring them in line with

### DIFF
--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -217,7 +217,9 @@ control 'cis-dil-benchmark-4.1.8' do
   only_if { cis_level == 2 }
 
   describe file('/etc/audit/audit.rules') do
+    # its(:content) { should match(%r{^-w /var/log/faillog -p wa -k logins$}) } # Remove checks on /var/log/faillog as they don't exist in AL2 and not mentioned in the benchmark.
     its(:content) { should match(%r{^-w /var/log/lastlog -p wa -k logins$}) }
+    # its(:content) { should match(%r{^-w /var/log/tallylog -p wa -k logins$}) } # Remove checks on /var/log/tallylog as they don't exist in AL2 and not mentioned in the benchmark.
   end
 end
 

--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -217,9 +217,7 @@ control 'cis-dil-benchmark-4.1.8' do
   only_if { cis_level == 2 }
 
   describe file('/etc/audit/audit.rules') do
-    its(:content) { should match(%r{^-w /var/log/faillog -p wa -k logins$}) }
     its(:content) { should match(%r{^-w /var/log/lastlog -p wa -k logins$}) }
-    its(:content) { should match(%r{^-w /var/log/tallylog -p wa -k logins$}) }
   end
 end
 

--- a/controls/5_3_configure_pam.rb
+++ b/controls/5_3_configure_pam.rb
@@ -52,8 +52,8 @@ control 'cis-dil-benchmark-5.3.1' do # rubocop:disable Metrics/BlockLength
     describe.one do
       %w(common-password system-auth).each do |f|
         describe file("/etc/pam.d/#{f}") do
-          its(:content) { should match(/^password\s+requisite pam_pwquality\.so (\S+\s+)*retry=[3210]/) }
-          its(:content) { should match(/^password\s+requisite pam_pwquality\.so (\S+\s+)*try_first_pass/) }
+          its(:content) { should match(/^password\s+requisite pam_pwquality\.so (\S+\s+)*retry=[3210]/) } # '\s+' after 'password' fixes the regex to account for extra whitespaces introduced by Ansible's PAM module. This fixes 8 false failed controls.
+          its(:content) { should match(/^password\s+requisite pam_pwquality\.so (\S+\s+)*try_first_pass/) } # '\s+' after 'password' fixes the regex to account for extra whitespaces introduced by Ansible's PAM module. This fixes 8 false failed controls.
         end
       end
     end
@@ -92,11 +92,11 @@ control 'cis-dil-benchmark-5.3.3' do
   describe.one do
     %w(common-password system-auth).each do |f|
       describe file("/etc/pam.d/#{f}") do
-        its(:content) { should match(/^password\s+(\S+\s+)+pam_unix\.so (\S+\s+)*remember=([56789]|[1-9][0-9]+)/) }
+        its(:content) { should match(/^password\s+(\S+\s+)+pam_unix\.so (\S+\s+)*remember=([56789]|[1-9][0-9]+)/) } # '\s+' after 'password' fixes the regex to account for extra whitespaces introduced by Ansible's PAM module. This fixes 8 false failed controls.
       end
 
       describe file("/etc/pam.d/#{f}") do
-        its(:content) { should match(/^password\s+(\S+\s+)+pam_pwhistory\.so (\S+\s+)*remember=([56789]|[1-9][0-9]+)/) }
+        its(:content) { should match(/^password\s+(\S+\s+)+pam_pwhistory\.so (\S+\s+)*remember=([56789]|[1-9][0-9]+)/) } # '\s+' after 'password' fixes the regex to account for extra whitespaces introduced by Ansible's PAM module. This fixes 8 false failed controls.
       end
     end
   end

--- a/controls/5_3_configure_pam.rb
+++ b/controls/5_3_configure_pam.rb
@@ -52,8 +52,8 @@ control 'cis-dil-benchmark-5.3.1' do # rubocop:disable Metrics/BlockLength
     describe.one do
       %w(common-password system-auth).each do |f|
         describe file("/etc/pam.d/#{f}") do
-          its(:content) { should match(/^password requisite pam_pwquality\.so (\S+\s+)*retry=[3210]/) }
-          its(:content) { should match(/^password requisite pam_pwquality\.so (\S+\s+)*try_first_pass/) }
+          its(:content) { should match(/^password\s+requisite pam_pwquality\.so (\S+\s+)*retry=[3210]/) }
+          its(:content) { should match(/^password\s+requisite pam_pwquality\.so (\S+\s+)*try_first_pass/) }
         end
       end
     end
@@ -92,11 +92,11 @@ control 'cis-dil-benchmark-5.3.3' do
   describe.one do
     %w(common-password system-auth).each do |f|
       describe file("/etc/pam.d/#{f}") do
-        its(:content) { should match(/^password (\S+\s+)+pam_unix\.so (\S+\s+)*remember=([56789]|[1-9][0-9]+)/) }
+        its(:content) { should match(/^password\s+(\S+\s+)+pam_unix\.so (\S+\s+)*remember=([56789]|[1-9][0-9]+)/) }
       end
 
       describe file("/etc/pam.d/#{f}") do
-        its(:content) { should match(/^password (\S+\s+)+pam_pwhistory\.so (\S+\s+)*remember=([56789]|[1-9][0-9]+)/) }
+        its(:content) { should match(/^password\s+(\S+\s+)+pam_pwhistory\.so (\S+\s+)*remember=([56789]|[1-9][0-9]+)/) }
       end
     end
   end

--- a/controls/6_1_system_file_permissions.rb
+++ b/controls/6_1_system_file_permissions.rb
@@ -83,8 +83,8 @@ control 'cis-dil-benchmark-6.1.3' do
   shadow_files.each do |f|
     describe file(f) do
       it { should exist }
-      it { should be_readable.by 'owner' }
-      it { should be_writable.by 'owner' }
+      it { should_not be_readable.by 'owner' }
+      it { should_not be_writable.by 'owner' }
       it { should_not be_executable.by 'owner' }
       it { should_not be_writable.by 'group' }
       it { should_not be_executable.by 'group' }
@@ -149,8 +149,8 @@ control 'cis-dil-benchmark-6.1.5' do
   gshadow_files.each do |f|
     describe file(f) do
       it { should exist }
-      it { should be_readable.by 'owner' }
-      it { should be_writable.by 'owner' }
+      it { should_not be_readable.by 'owner' }
+      it { should_not be_writable.by 'owner' }
       it { should_not be_executable.by 'owner' }
       it { should_not be_writable.by 'group' }
       it { should_not be_executable.by 'group' }
@@ -179,8 +179,10 @@ control 'cis-dil-benchmark-6.1.6' do
     it { should be_readable.by 'owner' }
     it { should be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
+    it { should be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
+    it { should be_readable.by 'other' }
     it { should_not be_writable.by 'other' }
     it { should_not be_executable.by 'other' }
     its(:uid) { should cmp 0 }
@@ -201,9 +203,10 @@ control 'cis-dil-benchmark-6.1.7' do
 
   describe file('/etc/shadow-') do
     it { should exist }
-    it { should be_readable.by 'owner' }
-    it { should be_writable.by 'owner' }
+    it { should_not be_readable.by 'owner' }
+    it { should_not be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
+    it { should_not be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
     it { should_not be_readable.by 'other' }
@@ -254,9 +257,10 @@ control 'cis-dil-benchmark-6.1.9' do
 
   describe file('/etc/gshadow-') do
     it { should exist }
-    it { should be_readable.by 'owner' }
-    it { should be_writable.by 'owner' }
+    it { should_not be_readable.by 'owner' }
+    it { should_not be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
+    it { should_not be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
     it { should_not be_readable.by 'other' }

--- a/controls/6_1_system_file_permissions.rb
+++ b/controls/6_1_system_file_permissions.rb
@@ -86,6 +86,7 @@ control 'cis-dil-benchmark-6.1.3' do
       it { should_not be_readable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
       it { should_not be_writable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
       it { should_not be_executable.by 'owner' }
+      it { should_not be_readable.by 'group' }
       it { should_not be_writable.by 'group' }
       it { should_not be_executable.by 'group' }
       it { should_not be_readable.by 'other' }
@@ -152,6 +153,7 @@ control 'cis-dil-benchmark-6.1.5' do
       it { should_not be_readable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
       it { should_not be_writable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
       it { should_not be_executable.by 'owner' }
+      it { should_not be_readable.by 'group' }
       it { should_not be_writable.by 'group' }
       it { should_not be_executable.by 'group' }
       it { should_not be_readable.by 'other' }

--- a/controls/6_1_system_file_permissions.rb
+++ b/controls/6_1_system_file_permissions.rb
@@ -83,8 +83,8 @@ control 'cis-dil-benchmark-6.1.3' do
   shadow_files.each do |f|
     describe file(f) do
       it { should exist }
-      it { should_not be_readable.by 'owner' }
-      it { should_not be_writable.by 'owner' }
+      it { should_not be_readable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
+      it { should_not be_writable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
       it { should_not be_executable.by 'owner' }
       it { should_not be_writable.by 'group' }
       it { should_not be_executable.by 'group' }
@@ -149,8 +149,8 @@ control 'cis-dil-benchmark-6.1.5' do
   gshadow_files.each do |f|
     describe file(f) do
       it { should exist }
-      it { should_not be_readable.by 'owner' }
-      it { should_not be_writable.by 'owner' }
+      it { should_not be_readable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
+      it { should_not be_writable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
       it { should_not be_executable.by 'owner' }
       it { should_not be_writable.by 'group' }
       it { should_not be_executable.by 'group' }
@@ -179,10 +179,10 @@ control 'cis-dil-benchmark-6.1.6' do
     it { should be_readable.by 'owner' }
     it { should be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
-    it { should be_readable.by 'group' }
+    it { should be_readable.by 'group' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
-    it { should be_readable.by 'other' }
+    it { should be_readable.by 'other' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
     it { should_not be_writable.by 'other' }
     it { should_not be_executable.by 'other' }
     its(:uid) { should cmp 0 }
@@ -203,10 +203,10 @@ control 'cis-dil-benchmark-6.1.7' do
 
   describe file('/etc/shadow-') do
     it { should exist }
-    it { should_not be_readable.by 'owner' }
-    it { should_not be_writable.by 'owner' }
+    it { should_not be_readable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
+    it { should_not be_writable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
     it { should_not be_executable.by 'owner' }
-    it { should_not be_readable.by 'group' }
+    it { should_not be_readable.by 'group' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
     it { should_not be_readable.by 'other' }
@@ -257,10 +257,10 @@ control 'cis-dil-benchmark-6.1.9' do
 
   describe file('/etc/gshadow-') do
     it { should exist }
-    it { should_not be_readable.by 'owner' }
-    it { should_not be_writable.by 'owner' }
+    it { should_not be_readable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
+    it { should_not be_writable.by 'owner' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
     it { should_not be_executable.by 'owner' }
-    it { should_not be_readable.by 'group' }
+    it { should_not be_readable.by 'group' } # Bring the /etc/passwd,group,shadow,... file permissions in line with CIS AL2 Benchmark v1.0.0 recommendations.
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
     it { should_not be_readable.by 'other' }


### PR DESCRIPTION
CIS Amazon Linux 2 benchmark v1.0.0 and get rid of false failures.